### PR TITLE
Add ability to plot on absolute time (chendaniely/ebola#3)

### DIFF
--- a/analyses/shinyCountryTimeseries/server.R
+++ b/analyses/shinyCountryTimeseries/server.R
@@ -60,9 +60,10 @@ shinyServer(function(input, output) {
 
 
   plot <- reactive({
+	type = paste0(input$date_offset,".days")
     g <- ggplot(data = data_plot(),
-                aes(x = relative.days, y = count,
-                    group = place, color = place)) +
+                aes_string(x = type, y = "count",
+                    group = "place", color = "place")) +
                         geom_point() + geom_line()+
                             facet_grid(~ type) +
                                 scale_x_continuous(name="Days after first report") +

--- a/analyses/shinyCountryTimeseries/ui.R
+++ b/analyses/shinyCountryTimeseries/ui.R
@@ -9,6 +9,7 @@ shinyUI(fluidPage(
     sidebarLayout(
         sidebarPanel("Interactive plot components",
                      uiOutput("countriesList"),
+					 radioButtons("date_offset", "Date range:", c("Relative"="relative", "Absolute"="absolute")),
                      checkboxInput("log", "Plot y-axis on log scale")
                      ),
 


### PR DESCRIPTION
Hi again,

I've tweaked the loading code some more so it keeps hold of the original "days" column. I've changed the UI to choose between timebases. The changes are [deployed here](https://mathew-hall.shinyapps.io/shinyCountryTimeseries/). 

This addresses issue chendaniely/ebola#3 but might break merges; I've renamed the data frame from `df5_melt` to `long`. Let me know if that's a problem and I'll fix in the PR.
